### PR TITLE
Create serveXXX methods to get rid of boilerplate code

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ We will soon create an example state handler in TypeScript.
 [lib/servicesdk]() - this is the only library that workflow writers need to interface with.  For example:
 
 ```TypeScript
+import {resource, serveWorkflow} from 'lyra-workflow';
 
-const wf = {
+// Import types used in workflow here, i.e. something similar to:
+// import * as Aws from './types/Aws';
+
+serveWorkflow({
   source: __filename,
   // define workflow here, see examples for how to do this
-}
-const sb = new ServiceBuilder('My::Service');
-sb.workflow(wf);
-const server = sb.build(global);
-console.log(server.metadata());
+});
 ```
 
 ## Testing

--- a/lib/examples/vpc_with_subnet.ts
+++ b/lib/examples/vpc_with_subnet.ts
@@ -1,4 +1,4 @@
-import {action, resource, ServiceBuilder} from '..';
+import {action, resource, serveWorkflow} from '..';
 
 import * as Aws from './Aws';
 
@@ -6,7 +6,7 @@ function makeRouteTable(vpcId: string, tags: {[s: string]: string}): Aws.RouteTa
   return new Aws.RouteTable({vpcId, tags});
 }
 
-const wf = {
+serveWorkflow({
   source: __filename,
   input: {tags: {type: 'StringHash', lookup: 'aws.tags'}},
 
@@ -52,9 +52,4 @@ const wf = {
       state: (vpcId: string, tags: {[s: string]: string}) => makeRouteTable(vpcId, tags)
     })
   }
-};
-
-const sb = new ServiceBuilder('My::Service');
-sb.workflow(wf);
-const server = sb.build(global);
-console.log(server.metadata());
+});

--- a/lib/servicesdk/ServiceBuilder.ts
+++ b/lib/servicesdk/ServiceBuilder.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import * as util from 'util';
 
+import {logger} from '..';
 import {Data} from '../pcore/Data';
 import {Deferred} from '../pcore/Deferred';
 import {Parameter} from '../pcore/Parameter';
@@ -67,6 +68,24 @@ export interface TopLevelActivityMap extends ActivityMap {
   source: string;
 }
 
+export function serveWorkflow(a: TopLevelActivityMap&WorkflowMap) {
+  const sb = new ServiceBuilder('Lyra::TypeScript::Service');
+  sb.workflow(a);
+  sb.serve();
+}
+
+export function serveAction(a: TopLevelActivityMap&ActionMap) {
+  const sb = new ServiceBuilder('Lyra::TypeScript::Service');
+  sb.action(a);
+  sb.serve();
+}
+
+export function serveResource(a: TopLevelActivityMap&ResourceMap) {
+  const sb = new ServiceBuilder('Lyra::TypeScript::Service');
+  sb.resource(a);
+  sb.serve();
+}
+
 export function action(a: ActionMap): ActionMap {
   a.style = 'action';
   return a;
@@ -112,6 +131,12 @@ export class ServiceBuilder {
 
   action(am: ActionMap&TopLevelActivityMap) {
     this.fromMap(am.source, ActionBuilder, action(am));
+  }
+
+  serve() {
+    const server = this.build(global);
+    logger.info('Starting the server', 'serverId', server.serviceId.toString());
+    server.start();
   }
 
   private fromMap<T extends ActivityBuilder>(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lyra-workflow",
-  "version": "0.1.2-beta.5",
+  "version": "0.1.2-beta.6",
   "description": "Lyra Workflow Back-end for TypeScript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -37,11 +37,11 @@
   ],
   "dependencies": {
     "@types/google-protobuf": "^3.2.7",
-    "@types/node": "^10.12.26",
+    "@types/node": "^10.14.4",
     "@types/sprintf-js": "^1.1.2",
-    "google-protobuf": "^3.7.0-rc.2",
-    "grpc": "^1.18.0",
-    "grpc-ts-health-check": "^1.0.10",
+    "google-protobuf": "^3.7.1",
+    "grpc": "^1.19.0",
+    "grpc-ts-health-check": "^1.0.11",
     "net": "^1.0.2",
     "protobufjs": "^6.8.8",
     "require-from-string": "^2.0.2",
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@types/jest": "^23.3.14",
-    "grpc-tools": "^1.6.6",
+    "grpc-tools": "^1.7.3",
     "grpc_tools_node_protoc_ts": "^2.5.0",
     "gts": "^0.9.0",
     "jest": "^23.6.0",


### PR DESCRIPTION
This commit adds the lyra-workflow methods:

    serveAction()
    serveWorkflow()
    serveResource()

to enable serving an action using just one single
function call in a manifest file.