### PR TITLE
Use Lyra::Parameter instead of Parameter

### DIFF
--- a/lib/pcore/Parameter.ts
+++ b/lib/pcore/Parameter.ts
@@ -7,10 +7,10 @@ import {StringHash, Value} from './Util';
 export class Parameter implements PcoreValue {
   readonly name: string;
   readonly type: Type;
+  readonly alias?: string;
   readonly value?: Value;
-  readonly captures?: boolean;
 
-  constructor(name: string, type?: string|Type, value?: Value, captures?: boolean) {
+  constructor(name: string, type?: string|Type, value?: Value, alias?: string) {
     this.name = name;
     if (type === undefined) {
       type = anyType;
@@ -20,7 +20,7 @@ export class Parameter implements PcoreValue {
 
     this.type = type;
     this.value = value;
-    this.captures = captures;
+    this.alias = alias;
   }
 
   [util.inspect.custom](depth: number, options: util.InspectOptions) {
@@ -28,7 +28,7 @@ export class Parameter implements PcoreValue {
   }
 
   __ptype(): string {
-    return 'Parameter';
+    return 'Lyra::Parameter';
   }
 
   __pvalue(): StringHash {
@@ -36,11 +36,8 @@ export class Parameter implements PcoreValue {
     if (this.value !== undefined) {
       m['value'] = this.value;
     }
-    if (this.value === null) {
-      m['has_value'] = true;
-    }
-    if (this.captures === true) {
-      m['captures_rest'] = true;
+    if (this.alias !== undefined) {
+      m['alias'] = this.alias;
     }
     return m;
   }

--- a/lib/servicesdk/ServiceBuilder.ts
+++ b/lib/servicesdk/ServiceBuilder.ts
@@ -326,23 +326,24 @@ export abstract class StepBuilder {
           }
 
           // Parameters parameters can have lookup, returns parameters can have alias.
-          let alu: Value;
+          let val: Value|undefined;
+          let alias: string|undefined;
           if (isIn) {
             const luv = (value as InParam).lookup;
             if (luv !== undefined) {
-              alu = new Deferred('lookup', luv);
+              val = new Deferred('lookup', luv);
             } else {
               throw new Error(`illegal parameters parameter assignment for parameter ${key}: ${value.toString()}`);
             }
           } else {
             const av = (value as OutParam).alias;
             if (av !== undefined) {
-              alu = av;
+              alias = av;
             } else {
               throw new Error(`illegal parameters parameter assignment for parameter ${key}: ${value.toString()}`);
             }
           }
-          result[key] = new Parameter(key, type, alu);
+          result[key] = new Parameter(key, type, val, alias);
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lyra-workflow",
-  "version": "0.1.2-rc.1",
+  "version": "0.1.2",
   "description": "Lyra Workflow Back-end for TypeScript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test/Serialization_spec.ts
+++ b/test/Serialization_spec.ts
@@ -119,7 +119,7 @@ describe('Serializer', () => {
 
     const createdObj = collector.value();
     const expectedObj = new Map(Object.entries({
-      __ptype: 'Parameter',
+      __ptype: 'Lyra::Parameter',
       name: 'x',
       type: new Map(Object.entries({
         __ptype: 'Type',


### PR DESCRIPTION
This commit follows a model change in the servicesdk
where the use of Parameter (from pcore) was replaced
with Lyra::Parameter (from servicesdk).